### PR TITLE
fetch product id on insert

### DIFF
--- a/src/Infrastructure/Connector/Action/Product/PatchProductAction.php
+++ b/src/Infrastructure/Connector/Action/Product/PatchProductAction.php
@@ -12,6 +12,7 @@ use Ergonode\ExporterShopware6\Infrastructure\Connector\AbstractAction;
 use Ergonode\ExporterShopware6\Infrastructure\Model\Shopware6Product;
 use GuzzleHttp\Psr7\Request;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Webmozart\Assert\Assert;
 
 class PatchProductAction extends AbstractAction
 {
@@ -22,6 +23,7 @@ class PatchProductAction extends AbstractAction
     public function __construct(Shopware6Product $product)
     {
         $this->product = $product;
+        Assert::notNull($product->getId());
     }
 
     public function getRequest(): Request

--- a/src/Infrastructure/Model/Shopware6Product.php
+++ b/src/Infrastructure/Model/Shopware6Product.php
@@ -701,6 +701,11 @@ class Shopware6Product implements JsonSerializable
         }
     }
 
+    public function setId(string $id): void
+    {
+        $this->id = $id;
+    }
+
     /**
      * @param Shopware6ProductCategory[] $categories
      */


### PR DESCRIPTION
When inserting product into shopware, `ShopwareProduct` object is not aware of its ID. That caused `PatchProductAction` to generate invalid url (without product id)